### PR TITLE
Break up and asyncify WebView initialization triggered by background …

### DIFF
--- a/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumAwInit.java
+++ b/android_webview/glue/java/src/com/android/webview/chromium/WebViewChromiumAwInit.java
@@ -4,10 +4,16 @@
 
 package com.android.webview.chromium;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.function.BiFunction;
+
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.os.Handler;
 import android.os.Looper;
 import android.os.Process;
 import android.util.Log;
@@ -50,6 +56,7 @@ import org.chromium.base.TraceEvent;
 import org.chromium.base.library_loader.LibraryLoader;
 import org.chromium.base.metrics.RecordHistogram;
 import org.chromium.base.metrics.ScopedSysTraceEvent;
+import org.chromium.base.task.ChoreographedExecutor;
 import org.chromium.base.task.PostTask;
 import org.chromium.content_public.browser.UiThreadTaskTraits;
 import org.chromium.net.NetworkChangeNotifier;
@@ -90,6 +97,8 @@ public class WebViewChromiumAwInit {
 
     // Read/write protected by mLock.
     private boolean mStarted;
+    private boolean mHasInitStarted;
+    private boolean mHasInitCompleted;
     private Looper mFirstWebViewConstructedOn;
 
     private final WebViewChromiumFactoryProvider mFactory;
@@ -135,9 +144,27 @@ public class WebViewChromiumAwInit {
             // return paths. (Other threads will not wake-up until we release |mLock|, whatever).
             mLock.notifyAll();
 
-            if (mStarted) {
+            if (mHasInitCompleted) {
+                assert mStarted;
                 return;
             }
+
+            // In the case of racing with an already-started init process, we need to wait until everything
+            // is done before returning.
+            if (mHasInitStarted) {
+                assert !mStarted;
+                while (!mHasInitCompleted) {
+                    try {
+                        // Important: wait() releases |mLock| the UI thread can take it :-)
+                        mLock.wait();
+                    } catch (InterruptedException e) {
+                        // Keep trying... eventually the UI thread will finish the initialization.
+                    }
+                }
+                assert mStarted;
+                return;
+            }
+            mHasInitStarted = true;
 
             final Context context = ContextUtils.getApplicationContext();
 
@@ -161,7 +188,6 @@ public class WebViewChromiumAwInit {
 
             initPlatSupportLibrary();
             doNetworkInitializations(context);
-
             waitUntilSetUpResources();
 
             // NOTE: Finished writing Java resources. From this point on, it's safe to use them.
@@ -203,6 +229,140 @@ public class WebViewChromiumAwInit {
             if (CommandLine.getInstance().hasSwitch(AwSwitches.WEBVIEW_VERBOSE_LOGGING)) {
                 logCommandLineAndActiveTrials();
             }
+
+            mHasInitCompleted = true;
+        }
+    }
+
+    protected CompletableFuture<Void> startChromiumIncrementallyAsync() {
+        try (ScopedSysTraceEvent e1 = ScopedSysTraceEvent.scoped("WebViewChromiumAwInit.startChromiumIncrementallyAsync")) {
+            assert ThreadUtils.runningOnUiThread();
+            assert Thread.holdsLock(mLock);
+
+            if (mHasInitCompleted) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            // TODO: Handle if init fails.
+            // In the case of racing with an already-started init process, we need to wait until everything
+            // is done before returning.
+            if (mHasInitStarted) {
+                assert !mHasInitCompleted;
+                while (!mHasInitCompleted) {
+                    try {
+                        // Important: wait() releases |mLock| the UI thread can take it :-)
+                        mLock.wait();
+                    } catch (InterruptedException e) {
+                        // Keep trying... eventually the UI thread will finish the initialization.
+                    }
+                }
+                
+                return CompletableFuture.completedFuture(null);
+            }
+            mHasInitStarted = true;
+
+            final Context context = ContextUtils.getApplicationContext();
+
+            Executor uiThreadExecutor = ChoreographedExecutor.getInstance(ThreadUtils.getUiThreadHandler());
+
+            return CompletableFuture.runAsync(() -> {
+                try (ScopedSysTraceEvent e2 =
+                            ScopedSysTraceEvent.scoped("WebViewChromiumAwInit.startChromiumIncrementallyAsync.rewriteJavaResources")) {
+                    assert ThreadUtils.runningOnUiThread();
+                    synchronized (mLock) {
+                        JNIUtils.setClassLoader(WebViewChromiumAwInit.class.getClassLoader());
+
+                        ResourceBundle.setAvailablePakLocales(
+                                new String[] {}, AwLocaleConfig.getWebViewSupportedPakLocales());
+
+                        BundleUtils.setIsBundle(ProductConfig.IS_BUNDLE);
+
+                        // We are rewriting Java resources in the background.
+                        // NOTE: Any reference to Java resources will cause a crash.
+
+                        try (ScopedSysTraceEvent e =
+                                        ScopedSysTraceEvent.scoped("WebViewChromiumAwInit.LibraryLoader")) {
+                            LibraryLoader.getInstance().ensureInitialized();
+                        }
+
+                        PathService.override(PathService.DIR_MODULE, "/system/lib/");
+                        PathService.override(DIR_RESOURCE_PAKS_ANDROID, "/system/framework/webview/paks");
+
+                        initPlatSupportLibrary();
+                    }
+                }
+            }, uiThreadExecutor).thenRunAsync(() -> {
+                try (ScopedSysTraceEvent e2 =
+                            ScopedSysTraceEvent.scoped("WebViewChromiumAwInit.startChromiumIncrementallyAsync.doNetworkInitializations")) {
+                    assert ThreadUtils.runningOnUiThread();
+                    synchronized (mLock) {
+                        doNetworkInitializations(context);
+                        waitUntilSetUpResources();
+                    }
+                }
+            }, uiThreadExecutor).thenRunAsync(() -> {
+                try (ScopedSysTraceEvent e2 =
+                            ScopedSysTraceEvent.scoped("WebViewChromiumAwInit.startChromiumIncrementallyAsync.configureChildProcessLauncher")) {
+                    assert ThreadUtils.runningOnUiThread();
+                    synchronized (mLock) {
+                        AwBrowserProcess.configureChildProcessLauncher();
+
+                        // finishVariationsInitLocked() must precede native initialization so the seed is
+                        // available when AwFeatureListCreator::SetUpFieldTrials() runs.
+                        finishVariationsInitLocked();
+                    }
+                }
+            }, uiThreadExecutor).thenComposeAsync((Void empty) -> {
+                try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("WebViewChromiumAwInit.startChromiumIncrementallyAsync.startAsync")) {
+                    assert ThreadUtils.runningOnUiThread();
+                    synchronized (mLock) {
+                        return AwBrowserProcess.startAsync();
+                    }
+                }
+            }, uiThreadExecutor).thenRunAsync(() -> {
+                try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("WebViewChromiumAwInit.startChromiumIncrementallyAsync.postStart")) {
+                    synchronized (mLock) {
+                        AwBrowserProcess.handleMinidumpsAndSetMetricsConsent(true /* updateMetricsConsent */);
+
+                        mSharedStatics = new SharedStatics();
+                        if (BuildInfo.isDebugAndroid()) {
+                            mSharedStatics.setWebContentsDebuggingEnabledUnconditionally(true);
+                        }
+
+                        mStarted = true;
+                    }
+                }
+            }, uiThreadExecutor).thenRunAsync(() -> {
+                try (ScopedSysTraceEvent e2 =
+                            ScopedSysTraceEvent.scoped("WebViewChromiumAwInit.startChromiumIncrementallyAsync.remainingWork")) {
+                    assert ThreadUtils.runningOnUiThread();
+                    synchronized (mLock) {
+                        RecordHistogram.recordSparseHistogram("Android.WebView.TargetSdkVersion",
+                                context.getApplicationInfo().targetSdkVersion);
+
+                        try (ScopedSysTraceEvent e = ScopedSysTraceEvent.scoped(
+                                    "WebViewChromiumAwInit.initThreadUnsafeSingletons")) {
+                            // Initialize thread-unsafe singletons.
+                            AwBrowserContext awBrowserContext = getBrowserContextOnUiThread();
+                            mGeolocationPermissions = new GeolocationPermissionsAdapter(
+                                    mFactory, awBrowserContext.getGeolocationPermissions());
+                            mWebStorage =
+                                    new WebStorageAdapter(mFactory, mBrowserContext.getQuotaManagerBridge());
+                            mAwTracingController = getTracingController();
+                            mServiceWorkerController = awBrowserContext.getServiceWorkerController();
+                            mAwProxyController = new AwProxyController();
+                        }
+
+                        mFactory.getRunQueue().drainQueue();
+
+                        if (CommandLine.getInstance().hasSwitch(AwSwitches.WEBVIEW_VERBOSE_LOGGING)) {
+                            logCommandLineAndActiveTrials();
+                        }
+                        mLock.notifyAll();
+                        mHasInitCompleted = true;
+                    }
+                }
+            }, uiThreadExecutor);
         }
     }
 
@@ -319,23 +479,27 @@ public class WebViewChromiumAwInit {
             return;
         }
 
-        // We must post to the UI thread to cover the case that the user has invoked Chromium
-        // startup by using the (thread-safe) CookieManager rather than creating a WebView.
-        AwThreadUtils.postToUiThreadLooper(new Runnable() {
-            @Override
-            public void run() {
-                synchronized (mLock) {
-                    startChromiumLocked();
-                }
+        final CompletableFuture<Void> chromiumStarted = new CompletableFuture<>();
+        AwThreadUtils.postToUiThreadLooper(() -> {
+            synchronized (mLock) {
+                startChromiumIncrementallyAsync().thenRunAsync(() -> {
+                    chromiumStarted.complete(null);
+                });
             }
         });
-        while (!mStarted) {
+        while (!mHasInitCompleted) {
             try {
                 // Important: wait() releases |mLock| the UI thread can take it :-)
                 mLock.wait();
             } catch (InterruptedException e) {
                 // Keep trying... eventually the UI thread will process the task we sent it.
             }
+        }
+        // Wait until the Future has resolved. It should resolve quickly after mHasInitCompleted becomes true.
+        try {
+            chromiumStarted.get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/android_webview/java/src/org/chromium/android_webview/AwBrowserProcess.java
+++ b/android_webview/java/src/org/chromium/android_webview/AwBrowserProcess.java
@@ -8,6 +8,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.os.Handler;
 import android.os.IBinder;
 import android.os.ParcelFileDescriptor;
 import android.os.RemoteException;
@@ -42,6 +43,7 @@ import org.chromium.base.library_loader.LibraryLoader;
 import org.chromium.base.library_loader.LibraryProcessType;
 import org.chromium.base.metrics.RecordHistogram;
 import org.chromium.base.metrics.ScopedSysTraceEvent;
+import org.chromium.base.task.ChoreographedExecutor;
 import org.chromium.base.task.PostTask;
 import org.chromium.base.task.TaskRunner;
 import org.chromium.base.task.TaskTraits;
@@ -57,6 +59,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -127,22 +131,30 @@ public final class AwBrowserProcess {
      */
     public static void start() {
         try (ScopedSysTraceEvent e1 = ScopedSysTraceEvent.scoped("AwBrowserProcess.start")) {
-            final Context appContext = ContextUtils.getApplicationContext();
-            AwBrowserProcessJni.get().setProcessNameCrashKey(ContextUtils.getProcessName());
-            AwDataDirLock.lock(appContext);
+            Context tempAppContext = null;
+            try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("AwBrowserProcess.start.lockDataDir")) {
+                tempAppContext = ContextUtils.getApplicationContext();
+                AwBrowserProcessJni.get().setProcessNameCrashKey(ContextUtils.getProcessName());
+                AwDataDirLock.lock(tempAppContext);
+            }
+            final Context appContext = tempAppContext;
             // We must post to the UI thread to cover the case that the user
             // has invoked Chromium startup by using the (thread-safe)
             // CookieManager rather than creating a WebView.
             ThreadUtils.runOnUiThreadBlocking(() -> {
-                boolean multiProcess =
-                        CommandLine.getInstance().hasSwitch(AwSwitches.WEBVIEW_SANDBOXED_RENDERER);
-                if (multiProcess) {
-                    ChildProcessLauncherHelper.warmUp(appContext, true);
+                boolean multiProcess = false;
+                try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("AwBrowserProcess.start.checkMultiProcess")) {
+                    multiProcess = CommandLine.getInstance().hasSwitch(AwSwitches.WEBVIEW_SANDBOXED_RENDERER);
+                    if (multiProcess) {
+                        ChildProcessLauncherHelper.warmUp(appContext, true);
+                    }
                 }
                 // The policies are used by browser startup, so we need to register the policy
                 // providers before starting the browser process. This only registers java objects
                 // and doesn't need the native library.
-                CombinedPolicyProvider.get().registerProvider(new AwPolicyProvider(appContext));
+                try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("AwBrowserProcess.start.registerPolicyProvider")) {
+                    CombinedPolicyProvider.get().registerProvider(new AwPolicyProvider(appContext));
+                }
 
                 // Check android settings but only when safebrowsing is enabled.
                 try (ScopedSysTraceEvent e2 =
@@ -158,6 +170,49 @@ public final class AwBrowserProcess {
 
                 PowerMonitor.create();
             });
+        }
+    }
+
+    public static CompletableFuture<Void> startAsync() {
+        assert ThreadUtils.runningOnUiThread();
+        final Executor uiThreadExecutor = ChoreographedExecutor.getInstance(ThreadUtils.getUiThreadHandler());
+
+        try (ScopedSysTraceEvent e1 = ScopedSysTraceEvent.scoped("AwBrowserProcess.startAsync")) {
+            Context appContext = null;
+            try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("AwBrowserProcess.startAsync.lockDataDir")) {
+                appContext = ContextUtils.getApplicationContext();
+                AwBrowserProcessJni.get().setProcessNameCrashKey(ContextUtils.getProcessName());
+                AwDataDirLock.lock(appContext);
+            }
+            boolean tempMultiProcess = false;
+            try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("AwBrowserProcess.startAsync.checkMultiProcess")) {
+                tempMultiProcess = CommandLine.getInstance().hasSwitch(AwSwitches.WEBVIEW_SANDBOXED_RENDERER);
+                if (tempMultiProcess) {
+                    ChildProcessLauncherHelper.warmUp(appContext, true);
+                }
+            }
+            final boolean multiProcess = tempMultiProcess;
+            // The policies are used by browser startup, so we need to register the policy
+            // providers before starting the browser process. This only registers java objects
+            // and doesn't need the native library.
+            try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("AwBrowserProcess.startAsync.registerPolicyProvider")) {
+                CombinedPolicyProvider.get().registerProvider(new AwPolicyProvider(appContext));
+            }
+
+            // Check android settings but only when safebrowsing is enabled.
+            try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("AwBrowserProcess.startAsync.maybeEnable")) {
+                AwSafeBrowsingConfigHelper.maybeEnableSafeBrowsingFromManifest(appContext);
+            }
+
+            return CompletableFuture.runAsync(() -> {
+                assert ThreadUtils.runningOnUiThread();
+                try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("AwBrowserProcess.startAsync.startBrowserProcessesIncrementallyAsync")) {
+                    BrowserStartupController.getInstance().startBrowserProcessesIncrementallyAsync(
+                            LibraryProcessType.PROCESS_WEBVIEW, !multiProcess);
+                }
+
+                PowerMonitor.create();
+            }, uiThreadExecutor);
         }
     }
 

--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -3764,6 +3764,7 @@ if (is_android) {
       "android/java/src/org/chromium/base/supplier/Supplier.java",
       "android/java/src/org/chromium/base/task/AsyncTask.java",
       "android/java/src/org/chromium/base/task/BackgroundOnlyAsyncTask.java",
+      "android/java/src/org/chromium/base/task/ChoreographedExecutor.java",
       "android/java/src/org/chromium/base/task/ChoreographerTaskRunner.java",
       "android/java/src/org/chromium/base/task/ChromeThreadPoolExecutor.java",
       "android/java/src/org/chromium/base/task/DefaultTaskExecutor.java",

--- a/base/android/java/src/org/chromium/base/task/ChoreographedExecutor.java
+++ b/base/android/java/src/org/chromium/base/task/ChoreographedExecutor.java
@@ -1,0 +1,72 @@
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.base.task;
+
+import org.chromium.base.ThreadUtils;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.view.Choreographer;
+
+import java.util.HashMap;
+import java.util.Queue;
+import java.util.LinkedList;
+import java.util.concurrent.Executor;
+
+public class ChoreographedExecutor implements Executor {
+    private final Choreographer mChoreographer;
+    private final Handler mHandler;
+    private final Queue<Runnable> mQueue;
+
+    private static final HashMap<Handler, ChoreographedExecutor> sExecutors = new HashMap<>();
+
+    private ChoreographedExecutor(Handler handler) {
+        mChoreographer = Choreographer.getInstance();
+        mHandler = handler;
+        mQueue = new LinkedList<>();
+        assert mHandler.getLooper() == Looper.myLooper();
+    }
+
+    public static ChoreographedExecutor getInstance(Handler handler) {
+        if (sExecutors.containsKey(handler)) {
+            return sExecutors.get(handler);
+        } else {
+            ChoreographedExecutor executor = new ChoreographedExecutor(handler);
+            sExecutors.put(handler, executor);
+            return executor;
+        }
+    }
+
+    private void enqueueNextTaskForHandler() {
+        if (mQueue.isEmpty()) {
+            return;
+        }
+        Runnable r = mQueue.poll();
+        mHandler.post(r);
+        if (!mQueue.isEmpty()) {
+            postFrameCallback();
+        }
+    }
+
+    private void postFrameCallback() {
+        // The Choreographer will run the callback as part of the next frame render,
+        // so we post the original task to the Handler inside the frame render callback.
+        mChoreographer.postFrameCallback(new Choreographer.FrameCallback() {
+            @Override
+            public void doFrame(long frameTimeNanos) {
+                enqueueNextTaskForHandler();
+            }
+        });
+    }
+
+    @Override
+    public void execute(Runnable r) {
+        assert ThreadUtils.runningOnUiThread();
+        mQueue.add(r);
+        if (mQueue.size() == 1) {
+            postFrameCallback();
+        }
+    }
+}

--- a/content/app/content_main.cc
+++ b/content/app/content_main.cc
@@ -205,8 +205,40 @@ void InitializeMojo(mojo::core::Configuration* config) {
 
 }  // namespace
 
+#include <android/trace.h>
+#include <dlfcn.h>
+
+void *(*ATrace_beginSection) (const char* sectionName);
+void *(*ATrace_endSection) (void);
+
+typedef void *(*fp_ATrace_beginSection) (const char* sectionName);
+typedef void *(*fp_ATrace_endSection) (void);
+
+class ScopedTrace {
+  public:
+    inline ScopedTrace(const char *name) {
+      ATrace_beginSection(name);
+    }
+
+    inline ~ScopedTrace() {
+      ATrace_endSection();
+    }
+};
+
 int RunContentProcess(const ContentMainParams& params,
                       ContentMainRunner* content_main_runner) {
+  void *lib = dlopen("libandroid.so", RTLD_NOW || RTLD_LOCAL);
+  if (lib != NULL) {
+    // Use dlsym() to prevent crashes on devices running Android 5.1
+    // (API level 22) or lower.
+    ATrace_beginSection = reinterpret_cast<fp_ATrace_beginSection>(
+        dlsym(lib, "ATrace_beginSection"));
+    ATrace_endSection = reinterpret_cast<fp_ATrace_endSection>(
+        dlsym(lib, "ATrace_endSection"));
+  } else {
+    (void)*(void**)0x0;
+  }
+  ScopedTrace st0("RunContentProcess::ContentMainParams");
   ContentMainParams content_main_params(params);
 
   int exit_code = -1;
@@ -227,7 +259,10 @@ int RunContentProcess(const ContentMainParams& params,
 #if defined(OS_MAC) && BUILDFLAG(USE_ALLOCATOR_SHIM)
     base::allocator::InitializeAllocatorShim();
 #endif
-    base::EnableTerminationOnOutOfMemory();
+    {
+      ScopedTrace st1("RunContentProcess::EnableTerminationOnOutOfMemory");
+      base::EnableTerminationOnOutOfMemory();
+    }
 
 #if defined(OS_LINUX) || defined(OS_CHROMEOS)
     // The various desktop environments set this environment variable that
@@ -303,14 +338,26 @@ int RunContentProcess(const ContentMainParams& params,
     content_main_params.autorelease_pool = autorelease_pool.get();
     InitializeMac();
 #endif
-
     mojo::core::Configuration mojo_config;
-    mojo_config.max_message_num_bytes = kMaximumMojoMessageSize;
-    InitializeMojo(&mojo_config);
+    {
+      ScopedTrace st1("RunContentProcess::initMojo");
+      mojo_config.max_message_num_bytes = kMaximumMojoMessageSize;
+      InitializeMojo(&mojo_config);
+    }
 
-    ui::RegisterPathProvider();
-    tracker = base::debug::GlobalActivityTracker::Get();
-    exit_code = content_main_runner->Initialize(content_main_params);
+    {
+      ScopedTrace st1("RunContentProcess::registerPathProvider");
+      ui::RegisterPathProvider();
+    }
+    {
+      ScopedTrace st1("RunContentProcess::getActivityTracker");
+      tracker = base::debug::GlobalActivityTracker::Get();
+    }
+
+    {
+      ScopedTrace st1("RunContentProcess::initialize");
+      exit_code = content_main_runner->Initialize(content_main_params);
+    }
 
     if (exit_code >= 0) {
       if (tracker) {
@@ -332,21 +379,24 @@ int RunContentProcess(const ContentMainParams& params,
     // sandboxed process. The defines below must be in sync with the
     // implementation of mojo::NodeController::CreateSharedBuffer().
 #if !defined(OS_MAC) && !defined(OS_NACL_SFI) && !defined(OS_FUCHSIA)
-    if (sandbox::policy::IsUnsandboxedSandboxType(
-            sandbox::policy::SandboxTypeFromCommandLine(
-                *base::CommandLine::ForCurrentProcess()))) {
-      // Unsandboxed processes don't need shared memory brokering... because
-      // they're not sandboxed.
-    } else if (mojo_config.force_direct_shared_memory_allocation) {
-      // Don't bother with hooks if direct shared memory allocation has been
-      // requested.
-    } else {
-      // Sanity check, since installing the shared memory hooks in a broker
-      // process will lead to infinite recursion.
-      DCHECK(!mojo_config.is_broker_process);
-      // Otherwise, this is a sandboxed process that will need brokering to
-      // allocate shared memory.
-      mojo::SharedMemoryUtils::InstallBaseHooks();
+    {
+      ScopedTrace st1("RunContentProcess::installSharedMemoryHooks");
+      if (sandbox::policy::IsUnsandboxedSandboxType(
+              sandbox::policy::SandboxTypeFromCommandLine(
+                  *base::CommandLine::ForCurrentProcess()))) {
+        // Unsandboxed processes don't need shared memory brokering... because
+        // they're not sandboxed.
+      } else if (mojo_config.force_direct_shared_memory_allocation) {
+        // Don't bother with hooks if direct shared memory allocation has been
+        // requested.
+      } else {
+        // Sanity check, since installing the shared memory hooks in a broker
+        // process will lead to infinite recursion.
+        DCHECK(!mojo_config.is_broker_process);
+        // Otherwise, this is a sandboxed process that will need brokering to
+        // allocate shared memory.
+        mojo::SharedMemoryUtils::InstallBaseHooks();
+      }
     }
 #endif  // !defined(OS_MAC) && !defined(OS_NACL_SFI) && !defined(OS_FUCHSIA)
 
@@ -367,9 +417,14 @@ int RunContentProcess(const ContentMainParams& params,
     }
   }
 
-  if (IsSubprocess())
+  if (IsSubprocess()) {
+    ScopedTrace st1("RunContentProcess::commonSubprocessInit");
     CommonSubprocessInit();
-  exit_code = content_main_runner->Run(params.minimal_browser_mode);
+  }
+  {
+    ScopedTrace st1("RunContentProcess::content_main_runner::Run");
+    exit_code = content_main_runner->Run(params.minimal_browser_mode);
+  }
 
   if (tracker) {
     if (exit_code == 0) {

--- a/content/browser/browser_main_loop.cc
+++ b/content/browser/browser_main_loop.cc
@@ -246,8 +246,28 @@
 #undef DestroyAll
 #endif
 
+#include <android/trace.h>
+#include <dlfcn.h>
+
 namespace content {
 namespace {
+
+void *(*ATrace_beginSection) (const char* sectionName);
+void *(*ATrace_endSection) (void);
+
+typedef void *(*fp_ATrace_beginSection) (const char* sectionName);
+typedef void *(*fp_ATrace_endSection) (void);
+
+class ScopedTrace {
+  public:
+    inline ScopedTrace(const char *name) {
+      ATrace_beginSection(name);
+    }
+
+    inline ~ScopedTrace() {
+      ATrace_endSection();
+    }
+};
 
 #if defined(USE_GLIB)
 static void GLibLogHandler(const gchar* log_domain,
@@ -789,6 +809,7 @@ void BrowserMainLoop::PostMainMessageLoopStart() {
 
 int BrowserMainLoop::PreCreateThreads() {
   TRACE_EVENT0("startup", "BrowserMainLoop::PreCreateThreads");
+  ScopedTrace st1("BrowserMainLoop::PreCreateThreads");
 
   // Make sure no accidental call to initialize GpuDataManager earlier.
   DCHECK(!GpuDataManagerImpl::Initialized());
@@ -873,6 +894,19 @@ void BrowserMainLoop::CreateStartupTasks() {
   startup_task_runner_ = std::make_unique<StartupTaskRunner>(
       base::BindOnce(&BrowserStartupComplete),
       GetUIThreadTaskRunner({BrowserTaskType::kBootstrap}));
+
+  void *lib = dlopen("libandroid.so", RTLD_NOW || RTLD_LOCAL);
+  if (lib != NULL) {
+    // Use dlsym() to prevent crashes on devices running Android 5.1
+    // (API level 22) or lower.
+    ATrace_beginSection = reinterpret_cast<fp_ATrace_beginSection>(
+        dlsym(lib, "ATrace_beginSection"));
+    ATrace_endSection = reinterpret_cast<fp_ATrace_endSection>(
+        dlsym(lib, "ATrace_endSection"));
+  } else {
+    (void)*(void**)0x0;
+  }
+  ScopedTrace st1("BrowserMainLoop::CreateStartupTasks");
 #else
   startup_task_runner_ = std::make_unique<StartupTaskRunner>(
       base::OnceCallback<void(int)>(), base::ThreadTaskRunnerHandle::Get());
@@ -898,7 +932,8 @@ void BrowserMainLoop::CreateStartupTasks() {
   startup_task_runner_->AddTask(std::move(pre_main_message_loop_run));
 
 #if defined(OS_ANDROID)
-  startup_task_runner_->StartRunningTasksAsync();
+  bool throttled = true;
+  startup_task_runner_->StartRunningTasksAsync(throttled);
 #else
   startup_task_runner_->RunAllTasksNow();
 #endif
@@ -929,6 +964,7 @@ void BrowserMainLoop::SynchronouslyFlushStartupTasks() {
 
 int BrowserMainLoop::CreateThreads() {
   TRACE_EVENT0("startup,rail", "BrowserMainLoop::CreateThreads");
+  ScopedTrace st1("BrowserMainLoop::CreateThreads");
 
   // Release the ThreadPool's threads.
   scoped_execution_fence_.reset();
@@ -966,6 +1002,7 @@ int BrowserMainLoop::CreateThreads() {
 }
 
 int BrowserMainLoop::PostCreateThreads() {
+  ScopedTrace st1("BrowserMainLoop::PostCreateThreads");
   tracing_controller_ = std::make_unique<content::TracingControllerImpl>();
   content::BackgroundTracingManagerImpl::GetInstance()
       ->AddMetadataGeneratorFunction();
@@ -980,14 +1017,19 @@ int BrowserMainLoop::PostCreateThreads() {
 
 int BrowserMainLoop::PreMainMessageLoopRun() {
 #if defined(OS_ANDROID)
-  bool use_display_wide_color_gamut =
-      GetContentClient()->browser()->GetWideColorGamutHeuristic() ==
-      ContentBrowserClient::WideColorGamutHeuristic::kUseDisplay;
-  // Let screen instance be overridable by parts.
-  ui::SetScreenAndroid(use_display_wide_color_gamut);
+  ScopedTrace st1("BrowserMainLoop::PreMainMessageLoopRun");
+  {
+    ScopedTrace st2("BrowserMainLoop::use_display_wide_color_gamut");
+    bool use_display_wide_color_gamut =
+        GetContentClient()->browser()->GetWideColorGamutHeuristic() ==
+        ContentBrowserClient::WideColorGamutHeuristic::kUseDisplay;
+    // Let screen instance be overridable by parts.
+    ui::SetScreenAndroid(use_display_wide_color_gamut);
+  }
 #endif
 
   if (parts_) {
+    ScopedTrace st3("BrowserMainLoop::parts::PreMainMessageLoopRun");
     TRACE_EVENT0("startup", "BrowserMainLoop::PreMainMessageLoopRun");
 
     parts_->PreMainMessageLoopRun();
@@ -1194,6 +1236,7 @@ void BrowserMainLoop::InitializeMainThread() {
 
 int BrowserMainLoop::BrowserThreadsStarted() {
   TRACE_EVENT0("startup", "BrowserMainLoop::BrowserThreadsStarted");
+  ScopedTrace st1("BrowserMainLoop::BrowserThreadsStarted");
 
   // Bring up Mojo IPC and the embedded Service Manager as early as possible.
   // Initializaing mojo requires the IO thread to have been initialized first,

--- a/content/browser/startup_task_runner.cc
+++ b/content/browser/startup_task_runner.cc
@@ -21,7 +21,7 @@ void StartupTaskRunner::AddTask(StartupTask callback) {
   task_list_.push_back(std::move(callback));
 }
 
-void StartupTaskRunner::StartRunningTasksAsync() {
+void StartupTaskRunner::StartRunningTasksAsync(bool throttled) {
   DCHECK(proxy_.get());
   int result = 0;
   if (task_list_.empty()) {
@@ -31,7 +31,11 @@ void StartupTaskRunner::StartRunningTasksAsync() {
   } else {
     base::OnceClosure next_task =
         base::BindOnce(&StartupTaskRunner::WrappedTask, base::Unretained(this));
-    proxy_->PostNonNestableTask(FROM_HERE, std::move(next_task));
+    if (throttled) {
+      proxy_->PostNonNestableDelayedTask(FROM_HERE, std::move(next_task), base::TimeDelta::FromMilliseconds(16));
+    } else {
+      proxy_->PostNonNestableTask(FROM_HERE, std::move(next_task));
+    }
   }
 }
 

--- a/content/browser/startup_task_runner.h
+++ b/content/browser/startup_task_runner.h
@@ -46,7 +46,7 @@ class CONTENT_EXPORT StartupTaskRunner {
   void AddTask(StartupTask callback);
 
   // Start running the tasks asynchronously.
-  void StartRunningTasksAsync();
+  void StartRunningTasksAsync(bool throttled = false);
 
   // Run all tasks, or all remaining tasks, synchronously
   void RunAllTasksNow();

--- a/content/public/android/java/src/org/chromium/content/browser/BrowserStartupControllerImpl.java
+++ b/content/public/android/java/src/org/chromium/content/browser/BrowserStartupControllerImpl.java
@@ -5,6 +5,7 @@
 package org.chromium.content.browser;
 
 import android.content.Context;
+import android.os.Handler;
 import android.os.StrictMode;
 
 import androidx.annotation.IntDef;
@@ -22,6 +23,7 @@ import org.chromium.base.library_loader.LibraryProcessType;
 import org.chromium.base.library_loader.LoaderErrors;
 import org.chromium.base.library_loader.ProcessInitException;
 import org.chromium.base.metrics.ScopedSysTraceEvent;
+import org.chromium.base.task.ChoreographedExecutor;
 import org.chromium.base.task.PostTask;
 import org.chromium.content.app.ContentMain;
 import org.chromium.content.browser.ServicificationStartupUma.ServicificationStartup;
@@ -33,6 +35,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Implementation of {@link BrowserStartupController}.
@@ -236,16 +240,18 @@ public class BrowserStartupControllerImpl implements BrowserStartupController {
     @Override
     public void startBrowserProcessesSync(
             @LibraryProcessType int libraryProcessType, boolean singleProcess) {
-        assertProcessTypeSupported(libraryProcessType);
+        try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("BrowserStartupController.startBrowserProcessesSync.prelude")) {
 
-        ServicificationStartupUma.getInstance().record(ServicificationStartupUma.getStartupMode(
-                mFullBrowserStartupDone, mMinimalBrowserStarted, false /* startMinimalBrowser */));
+            assertProcessTypeSupported(libraryProcessType);
+
+            ServicificationStartupUma.getInstance().record(ServicificationStartupUma.getStartupMode(
+                    mFullBrowserStartupDone, mMinimalBrowserStarted, false /* startMinimalBrowser */));
+        }
 
         // If already started skip to checking the result
         if (!mFullBrowserStartupDone) {
             if (!mHasStartedInitializingBrowserProcess || !mPostResourceExtractionTasksCompleted) {
-                try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped(
-                             "BrowserStartupController.prepareToStartBrowserProcess")) {
+                try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("BrowserStartupController.prepareToStartBrowserProcess")) {
                     prepareToStartBrowserProcess(singleProcess, null);
                 }
             }
@@ -277,25 +283,106 @@ public class BrowserStartupControllerImpl implements BrowserStartupController {
         }
     }
 
+    private CompletableFuture<Void> asyncAwaitBrowserStartupDone(final CompletableFuture<Void> future) {
+        assert ThreadUtils.runningOnUiThread();
+        if (mFullBrowserStartupDone) {
+            future.complete(null);
+        } else {
+            ThreadUtils.postOnUiThread(() -> {
+                asyncAwaitBrowserStartupDone(future);
+            });
+        }
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Void> startBrowserProcessesIncrementallyAsync(
+            @LibraryProcessType int libraryProcessType, boolean singleProcess) {
+        assert ThreadUtils.runningOnUiThread();
+
+        try (ScopedSysTraceEvent e = ScopedSysTraceEvent.scoped("BrowserStartupController.startBrowserProcessesAsync.preludeAsync")) {
+            assertProcessTypeSupported(libraryProcessType);
+
+            ServicificationStartupUma.getInstance().record(ServicificationStartupUma.getStartupMode(
+                mFullBrowserStartupDone, mMinimalBrowserStarted, false /* startMinimalBrowser */));
+        }
+
+        if (!mFullBrowserStartupDone) {
+            if (mHasStartedInitializingBrowserProcess) {
+                // TODO: Figure out what to do for mPostResourceExtractionTasksCompleted
+                return asyncAwaitBrowserStartupDone(new CompletableFuture<>());
+            }
+            mHasStartedInitializingBrowserProcess = true;
+
+            final Executor uiThreadExecutor = ChoreographedExecutor.getInstance(ThreadUtils.getUiThreadHandler());
+    
+            return CompletableFuture.supplyAsync(() -> {
+                assert ThreadUtils.runningOnUiThread();
+                try (ScopedSysTraceEvent e = ScopedSysTraceEvent.scoped("BrowserStartupController.prepareToStartBrowserProcessAsync")) {
+                    prepareToStartBrowserProcess(singleProcess, null);
+                }
+                try (ScopedSysTraceEvent e = ScopedSysTraceEvent.scoped("BrowserStartupController.contentStartAsync")) {
+                    if (!mHasCalledContentStart) {
+                        mCurrentBrowserStartType = BrowserStartType.FULL_BROWSER;
+                        if (contentStart() > 0) {
+                            // Failed. The callbacks may not have run, so run them.
+                            enqueueCallbackExecution(STARTUP_FAILURE);
+                            return false;
+                        }
+                    } else if (mCurrentBrowserStartType == BrowserStartType.MINIMAL_BROWSER) {
+                        mCurrentBrowserStartType = BrowserStartType.FULL_BROWSER;
+                        if (contentStart() > 0) {
+                            enqueueCallbackExecution(STARTUP_FAILURE);
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+
+            }, uiThreadExecutor).thenComposeAsync((startedSuccessfully) -> {
+                assert ThreadUtils.runningOnUiThread();
+                try (ScopedSysTraceEvent e = ScopedSysTraceEvent.scoped("BrowserStartupController.flushStartupTasksAsync")) {
+                    if (startedSuccessfully) {
+                        // We don't need to manually flush startup tasks synchronously because the browser's init starts flushing them,
+                        // so we just need to wait until we get a callback from the browser indicating it's done starting up.
+                        return asyncAwaitBrowserStartupDone(new CompletableFuture<>());
+                    }
+                    return CompletableFuture.completedFuture(null);
+                }
+            }, uiThreadExecutor);
+        }
+
+        assert mFullBrowserStartupDone;
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        if (mStartupSuccess) {
+            result.complete(null);
+        } else {
+            result.completeExceptionally(new ProcessInitException(LoaderErrors.NATIVE_STARTUP_FAILED));
+        }
+        return result;
+    }
+
     /**
      * Start the browser process by calling ContentMain.start().
      */
     int contentStart() {
-        int result = 0;
-        if (mContentMainCallbackForTests == null) {
-            boolean startMinimalBrowser =
-                    mCurrentBrowserStartType == BrowserStartType.MINIMAL_BROWSER;
-            result = contentMainStart(startMinimalBrowser);
-            // No need to launch the full browser again if we are launching full browser now.
-            if (!startMinimalBrowser) mLaunchFullBrowserAfterMinimalBrowserStart = false;
-        } else {
-            assert mCurrentBrowserStartType == BrowserStartType.FULL_BROWSER;
-            // Run the injected Runnable instead of ContentMain().
-            mContentMainCallbackForTests.run();
-            mLaunchFullBrowserAfterMinimalBrowserStart = false;
+        try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("BrowserStartupController.contentStart")) {
+           int result = 0;
+            if (mContentMainCallbackForTests == null) {
+                boolean startMinimalBrowser =
+                        mCurrentBrowserStartType == BrowserStartType.MINIMAL_BROWSER;
+                result = contentMainStart(startMinimalBrowser);
+                // No need to launch the full browser again if we are launching full browser now.
+                if (!startMinimalBrowser) mLaunchFullBrowserAfterMinimalBrowserStart = false;
+            } else {
+                assert mCurrentBrowserStartType == BrowserStartType.FULL_BROWSER;
+                // Run the injected Runnable instead of ContentMain().
+                mContentMainCallbackForTests.run();
+                mLaunchFullBrowserAfterMinimalBrowserStart = false;
+            }
+            mHasCalledContentStart = true;
+            return result;
         }
-        mHasCalledContentStart = true;
-        return result;
     }
 
     @Override
@@ -314,7 +401,9 @@ public class BrowserStartupControllerImpl implements BrowserStartupController {
 
     @VisibleForTesting
     void flushStartupTasks() {
-        BrowserStartupControllerImplJni.get().flushStartupTasks();
+        try (ScopedSysTraceEvent e2 = ScopedSysTraceEvent.scoped("BrowserStartupController.flushStartupTasks")) {
+            BrowserStartupControllerImplJni.get().flushStartupTasks();
+        }
     }
 
     @Override
@@ -456,17 +545,23 @@ public class BrowserStartupControllerImpl implements BrowserStartupController {
             StrictMode.setThreadPolicy(oldPolicy);
         }
 
+        Log.i("FIRST_FRAG", "LibraryLoader done");
+
         Runnable postResourceExtraction = new Runnable() {
             @Override
             public void run() {
+                Log.i("FIRST_FRAG", "postResourceExtraction");
                 if (!mPostResourceExtractionTasksCompleted) {
                     // TODO(yfriedman): Remove dependency on a command line flag for this.
                     DeviceUtilsImpl.addDeviceSpecificUserAgentSwitch();
                     BrowserStartupControllerImplJni.get().setCommandLineFlags(singleProcess);
+                    Log.i("FIRST_FRAG", "after JNI setCommandLineFlags");
                     mPostResourceExtractionTasksCompleted = true;
                 }
 
+                Log.i("FIRST_FRAG", "before completion callback");
                 if (completionCallback != null) completionCallback.run();
+                Log.i("FIRST_FRAG", "after completion callback");
             }
         };
 
@@ -474,6 +569,7 @@ public class BrowserStartupControllerImpl implements BrowserStartupController {
         if (completionCallback == null) {
             // If no continuation callback is specified, then force the resource extraction
             // to complete.
+            Log.i("FIRST_FRAG", "ResourceExtractor");
             ResourceExtractor.get().waitForCompletion();
             postResourceExtraction.run();
         } else {

--- a/content/public/android/java/src/org/chromium/content_public/browser/BrowserStartupController.java
+++ b/content/public/android/java/src/org/chromium/content_public/browser/BrowserStartupController.java
@@ -7,6 +7,8 @@ package org.chromium.content_public.browser;
 import org.chromium.base.library_loader.LibraryProcessType;
 import org.chromium.content.browser.BrowserStartupControllerImpl;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * This class controls how C++ browser main loop is started and ensures it happens only once.
  *
@@ -69,6 +71,22 @@ public interface BrowserStartupController {
      *                      the browser process
      */
     void startBrowserProcessesSync(
+            @LibraryProcessType int libraryProcessType, boolean singleProcess);
+
+    /**
+     * Start the browser process asynchronously.
+     *
+     * <p/>
+     * Note that this can only be called on the UI thread.
+     *
+     * @param libraryProcessType the type of process the shared library is loaded. It must be
+     *                           LibraryProcessType.PROCESS_BROWSER,
+     *                           LibraryProcessType.PROCESS_WEBVIEW or
+     *                           LibraryProcessType.PROCESS_WEBLAYER.
+     * @param singleProcess true iff the browser should run single-process, ie. keep renderers in
+     *                      the browser process
+     */
+    CompletableFuture<Void> startBrowserProcessesIncrementallyAsync(
             @LibraryProcessType int libraryProcessType, boolean singleProcess);
 
     /**

--- a/third_party/r8/desugar_jdk_libs.json
+++ b/third_party/r8/desugar_jdk_libs.json
@@ -35,7 +35,6 @@
         "java.util.function.DoubleToIntFunction",
         "java.util.function.DoubleToLongFunction",
         "java.util.function.DoubleUnaryOperator",
-        "java.util.function.Function",
         "java.util.function.IntBinaryOperator",
         "java.util.function.IntConsumer",
         "java.util.function.IntFunction",
@@ -104,7 +103,6 @@
         "j$.util.IntSummaryStatistics": "java.util.IntSummaryStatistics",
         "j$.util.DoubleSummaryStatistics": "java.util.DoubleSummaryStatistics",
         "java.util.stream.": "j$.util.stream.",
-        "java.util.function.": "j$.util.function.",
         "java.util.Comparators": "j$.util.Comparators",
         "java.util.DoubleSummaryStatistics": "j$.util.DoubleSummaryStatistics",
         "java.util.IntSummaryStatistics": "j$.util.IntSummaryStatistics",
@@ -180,7 +178,6 @@
       "api_level_below_or_equal": 23,
       "rewrite_prefix": {
         "java.util.stream.": "j$.util.stream.",
-        "java.util.function.": "j$.util.function.",
         "java.util.DoubleSummaryStatistics": "j$.util.DoubleSummaryStatistics",
         "java.util.IntSummaryStatistics": "j$.util.IntSummaryStatistics",
         "java.util.LongSummaryStatistics": "j$.util.LongSummaryStatistics",


### PR DESCRIPTION
…threads

WebView initialization currently takes a non-trivial amount of main-thread time.
When initializing Chromium due to being on the critical path to opening a link
this is fine. However, if an application wants to pay the initialization cost
earlier to speed up a future navigation it must still pay a hefty main-thread price,
which can cause animation jank in the app. To help mitigate this observable impact
on main thread performance, this diff introduces an alternate code path for
WebView initialization when triggered from a background thread. This code path
breaks up the higher level tasks within the intialization and enables them to
run asynchronously one after another. These tasks are scheduled by an Executor
that is synchronized with the frame rate via Choreographer frame callbacks,
which provides better guarantees that we will maintain good responsiveness
during the intialization process.